### PR TITLE
Introduce Target User

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,9 +58,6 @@ install:
 script:
   - "echo \"localhost\" > inventory"
 
-# Download galaxy dependencies if a requirement file for that TEST_SUITE exists
-  - "if [ -f test/integration/default/${TEST_SUITE}-requirements.yml ]; then ansible-galaxy install -vvvv -r test/integration/default/${TEST_SUITE}-requirements.yml; fi"
-
 #  - "ansible-lint tasks/main.yml"
 
 # Check the role/playbook's syntax.

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ script:
   - "echo \"localhost\" > inventory"
 
 # Download galaxy dependencies if a requirement file for that TEST_SUITE exists
-  - "if [ -f ${TEST_SUITE}-requirements.yml ]; then ansible-galaxy install -vvvv -r test/integration/default/${TEST_SUITE}-requirements.yml; fi"
+  - "if [ -f test/integration/default/${TEST_SUITE}-requirements.yml ]; then ansible-galaxy install -vvvv -r test/integration/default/${TEST_SUITE}-requirements.yml; fi"
 
 #  - "ansible-lint tasks/main.yml"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,26 @@
 os:
   - osx
 matrix:
-  osx_image:
-  # OS X 10.15
-    - xcode12
-  # OS X 10.14
-    - xcode11.2
-  # OS X 10.13
-    - xcode10.1
-  # OS X 10.12
-  #  - xcode9.2
-  env:
-    - TEST_SUITE='default'
-    - TEST_SUITE='target-user'
+  include:
+      # OS X 10.15
+    - osx_image: xcode12
+      env: TEST_SUITE='default'
+      # OS X 10.14
+    - osx_image: xcode11.2
+      env: TEST_SUITE='default'
+      # OS X 10.13
+    - osx_image: xcode10.1
+      env: TEST_SUITE='default'
+          # OS X 10.15
+    - osx_image: xcode12
+      env: TEST_SUITE='target-user'
+      # OS X 10.14
+    - osx_image: xcode11.2
+      env: TEST_SUITE='target-user'
+      # OS X 10.13
+    - osx_image: xcode10.1
+      env: TEST_SUITE='target-user'
+
 #language: python
 #python: "2.7"
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,22 +2,19 @@
 ## https://docs.travis-ci.com/user/osx-ci-environment/
 os:
   - osx
-
-osx_image:
-# OS X 10.15
-  - xcode12
-# OS X 10.14
-  - xcode11.2
-# OS X 10.13
-  - xcode10.1
-# OS X 10.12
-#  - xcode9.2
-jobs:
-  include:
-  - name: "Default"
-    env: TEST_SUITE='default'
-  - name: "Target User"
-    env: TEST_SUITE='target-user'
+matrix:
+  osx_image:
+  # OS X 10.15
+    - xcode12
+  # OS X 10.14
+    - xcode11.2
+  # OS X 10.13
+    - xcode10.1
+  # OS X 10.12
+  #  - xcode9.2
+  env:
+    - TEST_SUITE='default'
+    - TEST_SUITE='target-user'
 #language: python
 #python: "2.7"
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,14 @@ osx_image:
 # OS X 10.15
   - xcode12
 # OS X 10.14
-  # - xcode11.2
+  - xcode11.2
 # OS X 10.13
-  # - xcode10.1
+  - xcode10.1
 # OS X 10.12
 #  - xcode9.2
 env:
   matrix:
-    # - TEST_SUITE='default'
+    - TEST_SUITE='default'
     - TEST_SUITE='target-user'
 #language: python
 #python: "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,12 @@ osx_image:
   - xcode10.1
 # OS X 10.12
 #  - xcode9.2
-
+jobs:
+  include:
+  - name: "Default"
+    env: TEST_SUITE='default'
+  - name: "Target User"
+    env: TEST_SUITE='target-user'
 #language: python
 #python: "2.7"
 before_install:
@@ -58,14 +63,14 @@ script:
 #  - "ansible-lint tasks/main.yml"
 
 # Check the role/playbook's syntax.
-  - "ansible-playbook -i inventory --syntax-check test/integration/default/default.yml"
+  - "ansible-playbook -i inventory --syntax-check test/integration/default/${TEST_SUITE}.yml"
 
 # Run the role/playbook with ansible-playbook.
-  - "ansible-playbook -i inventory --connection=local --become -vvvv test/integration/default/default.yml"
+  - "ansible-playbook -i inventory --connection=local --become -vvvv test/integration/default/${TEST_SUITE}.yml"
 
 # Run the role/playbook again, checking to make sure it's idempotent.
 ## FIXME! known fail
-  - "ansible-playbook -i inventory test/integration/default/default.yml --connection=local --become | tee /tmp/idempotency.log | grep -q 'changed=0.*failed=0'  && (echo 'Idempotence test: pass' && exit 0)  || (echo 'Idempotence test: fail' && cat /tmp/idempotency.log && exit 0)"
+  - "ansible-playbook -i inventory test/integration/default/${TEST_SUITE}.yml --connection=local --become | tee /tmp/idempotency.log | grep -q 'changed=0.*failed=0'  && (echo 'Idempotence test: pass' && exit 0)  || (echo 'Idempotence test: fail' && cat /tmp/idempotency.log && exit 0)"
 
 after_script:
   - "ls -lA /Users/travis/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,27 +2,20 @@
 ## https://docs.travis-ci.com/user/osx-ci-environment/
 os:
   - osx
-matrix:
-  include:
-      # OS X 10.15
-    - osx_image: xcode12
-      env: TEST_SUITE='default'
-      # OS X 10.14
-    - osx_image: xcode11.2
-      env: TEST_SUITE='default'
-      # OS X 10.13
-    - osx_image: xcode10.1
-      env: TEST_SUITE='default'
-          # OS X 10.15
-    - osx_image: xcode12
-      env: TEST_SUITE='target-user'
-      # OS X 10.14
-    - osx_image: xcode11.2
-      env: TEST_SUITE='target-user'
-      # OS X 10.13
-    - osx_image: xcode10.1
-      env: TEST_SUITE='target-user'
-
+  
+osx_image:
+# OS X 10.15
+  - xcode12
+# OS X 10.14
+  - xcode11.2
+# OS X 10.13
+  - xcode10.1
+# OS X 10.12
+#  - xcode9.2
+env:
+  matrix:
+    - TEST_SUITE='default'
+    - TEST_SUITE='target-user'
 #language: python
 #python: "2.7"
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,14 @@ osx_image:
 # OS X 10.15
   - xcode12
 # OS X 10.14
-  - xcode11.2
+  # - xcode11.2
 # OS X 10.13
-  - xcode10.1
+  # - xcode10.1
 # OS X 10.12
 #  - xcode9.2
 env:
   matrix:
-    - TEST_SUITE='default'
+    # - TEST_SUITE='default'
     - TEST_SUITE='target-user'
 #language: python
 #python: "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ script:
   - "echo \"localhost\" > inventory"
 
 # Download galaxy dependencies if a requirement file for that TEST_SUITE exists
-  - "if [ -f ${TEST_SUITE}-requirements.yml ]; then ansible-galaxy install -r ${TEST_SUITE}-requirements.yml; fi"
+  - "if [ -f ${TEST_SUITE}-requirements.yml ]; then ansible-galaxy install -vvvv -r test/integration/default/${TEST_SUITE}-requirements.yml; fi"
 
 #  - "ansible-lint tasks/main.yml"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ script:
   - "echo \"localhost\" > inventory"
 
 # Download galaxy dependencies if a requirement file for that TEST_SUITE exists
-  - if [ -f ${TEST_SUITE}-requirements.yml ]; then ansible-galaxy install -r ${TEST_SUITE}-requirements.yml; fi"
+  - "if [ -f ${TEST_SUITE}-requirements.yml ]; then ansible-galaxy install -r ${TEST_SUITE}-requirements.yml; fi"
 
 #  - "ansible-lint tasks/main.yml"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 ## https://docs.travis-ci.com/user/osx-ci-environment/
 os:
   - osx
-  
+
 osx_image:
 # OS X 10.15
   - xcode12
@@ -57,6 +57,9 @@ install:
   - "{ echo '[defaults]'; echo 'roles_path = ../'; } >> ansible.cfg"
 script:
   - "echo \"localhost\" > inventory"
+
+# Download galaxy dependencies if a requirement file for that TEST_SUITE exists
+  - if [ -f ${TEST_SUITE}-requirements.yml ]; then ansible-galaxy install -r ${TEST_SUITE}-requirements.yml; fi"
 
 #  - "ansible-lint tasks/main.yml"
 

--- a/README.md
+++ b/README.md
@@ -42,14 +42,14 @@ See `test/integration/default/default.yml` for examples of applications installa
 
 ```
 target_user_id: "username"      # the name of the user we want the apps to belong to
-verbose: no
+verbose: False
 install_archives: ~/Downloads
 pip_path: /opt/local/bin/pip    # Homebrew's pip: /opt/local/bin/pip
 
 macos_apps_install_list:
   - { u: 'https://download.mozilla.org/?product=firefox-50.1.0-SSL&os=osx&lang=fr',
       f: 'firefox-50.1.0-SSL-fr.dmg',
-      v: yes,
+      v: True,
       s: '63c561051b1846f110ea60446a6578991a84d169e07dcfe1f4ea35aa4ca20e2a',
       n: 'Firefox',
       t: 'app',
@@ -73,7 +73,7 @@ macos_apps_install_list:
       to: '/Applications',                     # OPTIONAL # Destination name for the application
       versioncmd: '',                          # OPTIONAL # Specific command to retrieve the currently          installed application version
       plist_tag: '',                           # OPTIONAL # Plist tag that identify the application version
-      v: yes,                                 # OPTIONAL # Toggle file integrity verification after download         
+      v: True,                                 # OPTIONAL # Toggle file integrity verification after download         
       s: '63c5610...a20e2a',                   # OPTIONAL # Checksum value for file integrity verification
     }
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ For example
 See `test/integration/default/default.yml` for examples of applications installation.
 
 ```
+target_user_id: "username"      # the name of the user we want the apps to belong to
 verbose: no
 install_archives: ~/Downloads
 pip_path: /opt/local/bin/pip    # Homebrew's pip: /opt/local/bin/pip

--- a/README.md
+++ b/README.md
@@ -41,14 +41,14 @@ For example
 See `test/integration/default/default.yml` for examples of applications installation.
 
 ```
-verbose: false
+verbose: no
 install_archives: ~/Downloads
 pip_path: /opt/local/bin/pip    # Homebrew's pip: /opt/local/bin/pip
 
 macos_apps_install_list:
   - { u: 'https://download.mozilla.org/?product=firefox-50.1.0-SSL&os=osx&lang=fr',
       f: 'firefox-50.1.0-SSL-fr.dmg',
-      v: true,
+      v: yes,
       s: '63c561051b1846f110ea60446a6578991a84d169e07dcfe1f4ea35aa4ca20e2a',
       n: 'Firefox',
       t: 'app',
@@ -72,7 +72,7 @@ macos_apps_install_list:
       to: '/Applications',                     # OPTIONAL # Destination name for the application
       versioncmd: '',                          # OPTIONAL # Specific command to retrieve the currently          installed application version
       plist_tag: '',                           # OPTIONAL # Plist tag that identify the application version
-      v: true,                                 # OPTIONAL # Toggle file integrity verification after download         
+      v: yes,                                 # OPTIONAL # Toggle file integrity verification after download         
       s: '63c5610...a20e2a',                   # OPTIONAL # Checksum value for file integrity verification
     }
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,30 +1,30 @@
 ---
 
-verbose: no
+verbose: False
 target_user_id: "{{ ansible_user_id }}"
 install_archives: /private/var/_install
-remove_archives_after_install: no
+remove_archives_after_install: False
 pip_path: /opt/local/bin/pip ## macports
 #pip_path: /usr/local/bin/pip ## homebrew
 
 macos_apps_install_list:
     - { u: 'https://download.mozilla.org/?product=firefox-50.1.0-SSL&os=osx&lang=fr',
         f: 'firefox-50.1.0-SSL-fr.dmg',
-        v: yes,
+        v: True,
         s: '63c561051b1846f110ea60446a6578991a84d169e07dcfe1f4ea35aa4ca20e2a',
         n: 'Firefox',
         t: 'app',
         version: '50.1.0'
       }
     - { u: "https://download.documentfoundation.org/libreoffice/stable/5.2.3/mac/x86_64/LibreOffice_5.2.3_MacOS_x86-64.dmg",
-        v: yes,
+        v: True,
         s: '7f842a38e00312b6283341af3323433558bc155495cf54206dc88a5dd3abe277',
         n: 'LibreOffice',
         t: 'app',
         version: '5.2.3'
       }
     - { u: 'http://download.virtualbox.org/virtualbox/5.1.10/VirtualBox-5.1.10-112026-OSX.dmg',
-        v: no,
+        v: False,
         s: '3500f07be9f5e27a08c00cc626981230bdaf639f6fad0b82ecf731a0580cccef',
         n: 'VirtualBox',
         t: 'pkg',

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 
 verbose: false
+target_user_id: "{{ ansible_user_id }}"
 install_archives: /private/var/_install
 remove_archives_after_install: false
 pip_path: /opt/local/bin/pip ## macports

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,30 +1,30 @@
 ---
 
-verbose: false
+verbose: no
 target_user_id: "{{ ansible_user_id }}"
 install_archives: /private/var/_install
-remove_archives_after_install: false
+remove_archives_after_install: no
 pip_path: /opt/local/bin/pip ## macports
 #pip_path: /usr/local/bin/pip ## homebrew
 
 macos_apps_install_list:
     - { u: 'https://download.mozilla.org/?product=firefox-50.1.0-SSL&os=osx&lang=fr',
         f: 'firefox-50.1.0-SSL-fr.dmg',
-        v: true,
+        v: yes,
         s: '63c561051b1846f110ea60446a6578991a84d169e07dcfe1f4ea35aa4ca20e2a',
         n: 'Firefox',
         t: 'app',
         version: '50.1.0'
       }
     - { u: "https://download.documentfoundation.org/libreoffice/stable/5.2.3/mac/x86_64/LibreOffice_5.2.3_MacOS_x86-64.dmg",
-        v: true,
+        v: yes,
         s: '7f842a38e00312b6283341af3323433558bc155495cf54206dc88a5dd3abe277',
         n: 'LibreOffice',
         t: 'app',
         version: '5.2.3'
       }
     - { u: 'http://download.virtualbox.org/virtualbox/5.1.10/VirtualBox-5.1.10-112026-OSX.dmg',
-        v: false,
+        v: no,
         s: '3500f07be9f5e27a08c00cc626981230bdaf639f6fad0b82ecf731a0580cccef',
         n: 'VirtualBox',
         t: 'pkg',

--- a/tasks/archive-install.yml
+++ b/tasks/archive-install.yml
@@ -61,14 +61,24 @@
 - block:
   - debug:
       msg: "This app will be installed as the user `{{ target_user_id }}`"
-    # Actions for `app` `zip` and `compressed installer types
+  #   # Actions for `app` `zip` and `compressed installer types
+  # - name: Copy '{{ app_name }}' app to '{{ dest }}'
+  #   command: "cp -R '{{ mount_path }}/{{ app_basename }}' '{{ dest }}/'"
+  #   when:
+  #     - archive_extension == '.dmg'
+  #     - installer_type == 'app'
+  #   become: "{{ (target_user_id != ansible_user_id) | bool }}"
+  #   become_user: "{{ target_user_id }}"
   - name: Copy '{{ app_name }}' app to '{{ dest }}'
-    command: "cp -R '{{ mount_path }}/{{ app_basename }}' '{{ dest }}/'"
+    copy:
+      src: "{{ mount_path }}/{{ app_basename }}"
+      dest: "{{ dest }}/"
+      owner: "{{ target_user_id }}"
     when:
       - archive_extension == '.dmg'
       - installer_type == 'app'
-    become: "{{ (target_user_id != ansible_user_id) | bool }}"
-    become_user: "{{ target_user_id }}"
+    become: True
+  # become_user: "{{ target_user_id }}"
 
   # if the archive is a compressed file the app will be extrated directly to it's destination
   - name: Extract '{{ app_name }}' to {{ dest }}'

--- a/tasks/archive-install.yml
+++ b/tasks/archive-install.yml
@@ -41,7 +41,8 @@
     set_fact:
       pkg_path: "{{ mount_path }}/{{ installer_name }}"
     when: installer_name != ''
-  when: installer_type == 'installer' # end block
+  # end block
+  when: installer_type == 'installer'
 
 - block:
   # Actions for `pkg` installers contained in DMG archives
@@ -54,13 +55,13 @@
     set_fact:
       pkg_path: "{{ mount_path }}/{{ installer_name }}"
     when: installer_name != ''
-  when: installer_type == 'pkg' # end block
+  # end block
+  when: installer_type == 'pkg'
 
 - block:
+  # we want that the installed app will belong to the target-user
   - debug:
-      msg: "This app will be installed as the user `{{ become_user }}`"
-    # we want that the installed app will belong to the target-user
-    #
+      msg: "This app will be installed as the user `{{ target_user_id }}`"
     # Actions for `app` `zip` and `compressed installer types
   - name: Copy '{{ app_name }}' app to '{{ dest }}'
     command: "cp -R '{{ mount_path }}/{{ app_basename }}' '{{ dest }}/'"
@@ -77,7 +78,8 @@
       - archive_extension != '.dmg'
       - (installer_type == 'zip' or installer_type == 'compressed_archive')
     ignore_errors: yes
-  when: installer_type != 'pkg' # end block
+  # end block
+  when: installer_type != 'pkg' and installer_type != 'pkgonly'
   become: "{{ (target_user_id != ansible_user_id) | bool }}"
   become_user: "{{ target_user_id }}"
 
@@ -89,8 +91,9 @@
   ##      http://help.preyproject.com/article/188-prey-unattended-install-for-computers
   - name: Run install of "{{ app_name }}.pkg"
     shell: "{{ env }} installer -package '{{ pkg_path | expanduser }}' -target /"
-    when: installer_type == 'pkg' or installer_type == 'pkgonly'
     ignore_errors: yes
+  # end block
+  when: installer_type == 'pkg' or installer_type == 'pkgonly'
   become: yes
 
 # this task cannot be escalated to super-user or target-user because it will trigger a GUI interactive installation process

--- a/tasks/archive-install.yml
+++ b/tasks/archive-install.yml
@@ -3,11 +3,11 @@
 ## MIT License, Copyright (c) 2013 Michael Griffin, http://mwgriffin.com
 
 - debug:
-    msg: "Archive Path {{pkg_path}}"
+    msg: "Archive Path {{ pkg_path }}"
   when: verbose|bool
 
 - debug:
-    msg: "Archive extension '{{archive_extension}}'"
+    msg: "Archive extension '{{ archive_extension }}'"
 
 - name: Check if dmg file '{{ app_archive }}' is mounted as '{{ mount_path }}'
   stat:
@@ -26,7 +26,7 @@
   # we want the super-user to remvoe the existing app in case it was installed by another user
   - name: Remove existing app if present
     file:
-      path: "{{ dest }}/{{app_basename}}"
+      path: "{{ dest }}/{{ app_basename }}"
       state: absent
     when: installer_type == 'app' or installer_type == 'zip' or installer_type == 'compressed_archive'
   become: True

--- a/tasks/archive-install.yml
+++ b/tasks/archive-install.yml
@@ -59,7 +59,6 @@
   when: installer_type == 'pkg'
 
 - block:
-  # we want that the installed app will belong to the target-user
   - debug:
       msg: "This app will be installed as the user `{{ target_user_id }}`"
     # Actions for `app` `zip` and `compressed installer types
@@ -79,16 +78,17 @@
       - (installer_type == 'zip' or installer_type == 'compressed_archive')
     ignore_errors: yes
   # end block
-  when: installer_type != 'pkg' and installer_type != 'pkgonly'
+  when: installer_type == 'app' or installer_type == 'zip 'and installer_type == 'compressed_archive'
   become: "{{ (target_user_id != ansible_user_id) | bool }}"
   become_user: "{{ target_user_id }}"
 
 - block:
   # This block is run as super-user because pkg installation frequently contain
   # system components that require the higher provileges to be installed in system paths
-  #
+  - debug:
+    msg: "This app will be installed as the user `{{ become_user }}`"
   ## Note: env allow to pass variables like API_key for
-  ##      http://help.preyproject.com/article/188-prey-unattended-install-for-computers
+  ## http://help.preyproject.com/article/188-prey-unattended-install-for-computers
   - name: Run install of "{{ app_name }}.pkg"
     shell: "{{ env }} installer -package '{{ pkg_path | expanduser }}' -target /"
     ignore_errors: yes
@@ -98,10 +98,15 @@
 
 # this task cannot be escalated to super-user or target-user because it will trigger a GUI interactive installation process
 # so it is valid only if the role is used to install apps on behalf of the same user that is running the deployment
-- name: Run interactive install of "{{ app_name }}"
-  shell: "{{ env }} open '{{ pkg_path | expanduser }}'"
+- block:
+  - debug:
+      msg: "This app will be installed as the user `{{ ansinle_user_id }}`"
+
+  - name: Run interactive install of "{{ app_name }}"
+    shell: "{{ env }} open '{{ pkg_path | expanduser }}'"
+    ignore_errors: yes
+  # end block
   when: installer_type == 'installer'
-  ignore_errors: yes
 
 # this task is run asyncronously and retried various times
 # because somethims some volumes are still locked by some processes

--- a/tasks/archive-install.yml
+++ b/tasks/archive-install.yml
@@ -57,6 +57,8 @@
   when: installer_type == 'pkg' # end block
 
 - block:
+  - debug:
+      msg: "This app will be installed as the user `{{ become_user }}`"
     # we want that the installed app will belong to the target-user
     #
     # Actions for `app` `zip` and `compressed installer types

--- a/tasks/archive-install.yml
+++ b/tasks/archive-install.yml
@@ -86,7 +86,7 @@
   # This block is run as super-user because pkg installation frequently contain
   # system components that require the higher provileges to be installed in system paths
   - debug:
-    msg: "This app will be installed as the user `{{ become_user }}`"
+      msg: "This app will be installed as the user `{{ become_user }}`"
   ## Note: env allow to pass variables like API_key for
   ## http://help.preyproject.com/article/188-prey-unattended-install-for-computers
   - name: Run install of "{{ app_name }}.pkg"

--- a/tasks/archive-install.yml
+++ b/tasks/archive-install.yml
@@ -20,7 +20,7 @@
   # shell: "yes qy | hdiutil attach '{{ pkg_path | expanduser }}'"
   shell: "yes qy | hdiutil attach '{{ pkg_path }}' -mountpoint '{{ mount_path }}'"
   when: archive_extension == '.dmg' and mounted is defined and not mounted.stat.exists
-  changed_when: false
+  changed_when: no
 
 - block:
   # we want the super-user to remvoe the existing app in case it was installed by another user
@@ -74,7 +74,7 @@
     when:
       - archive_extension != '.dmg'
       - (installer_type == 'zip' or installer_type == 'compressed_archive')
-    ignore_errors: true
+    ignore_errors: yes
   when: installer_type != 'pkg' # end block
   become: "{{ (target_user_id != ansible_user_id) | bool }}"
   become_user: "{{ target_user_id }}"
@@ -88,7 +88,7 @@
   - name: Run install of "{{ app_name }}.pkg"
     shell: "{{ env }} installer -package '{{ pkg_path | expanduser }}' -target /"
     when: installer_type == 'pkg' or installer_type == 'pkgonly'
-    ignore_errors: true
+    ignore_errors: yes
   become: yes
 
 # this task cannot be escalated to super-user or target-user because it will trigger a GUI interactive installation process
@@ -96,7 +96,7 @@
 - name: Run interactive install of "{{ app_name }}"
   shell: "{{ env }} open '{{ pkg_path | expanduser }}'"
   when: installer_type == 'installer'
-  ignore_errors: true
+  ignore_errors: yes
 
 # this task is run asyncronously and retried various times
 # because somethims some volumes are still locked by some processes
@@ -105,7 +105,7 @@
   command: "hdiutil detach '{{ mount_path | expanduser }}'"
   when: archive_extension == '.dmg'
   register: unmount_result
-  changed_when: false
+  changed_when: no
   retries: 20
   delay: 10
   until: unmount_result is not failed

--- a/tasks/archive-install.yml
+++ b/tasks/archive-install.yml
@@ -61,14 +61,7 @@
 - block:
   - debug:
       msg: "This app will be installed as the user `{{ target_user_id }}`"
-  #   # Actions for `app` `zip` and `compressed installer types
-  # - name: Copy '{{ app_name }}' app to '{{ dest }}'
-  #   command: "cp -R '{{ mount_path }}/{{ app_basename }}' '{{ dest }}/'"
-  #   when:
-  #     - archive_extension == '.dmg'
-  #     - installer_type == 'app'
-  #   become: "{{ (target_user_id != ansible_user_id) | bool }}"
-  #   become_user: "{{ target_user_id }}"
+
   - name: Copy '{{ app_name }}' app to '{{ dest }}'
     copy:
       src: "{{ mount_path }}/{{ app_basename }}"

--- a/tasks/archive-install.yml
+++ b/tasks/archive-install.yml
@@ -20,7 +20,7 @@
   # shell: "yes qy | hdiutil attach '{{ pkg_path | expanduser }}'"
   shell: "yes qy | hdiutil attach '{{ pkg_path }}' -mountpoint '{{ mount_path }}'"
   when: archive_extension == '.dmg' and mounted is defined and not mounted.stat.exists
-  changed_when: no
+  changed_when: False
 
 - block:
   # we want the super-user to remvoe the existing app in case it was installed by another user
@@ -29,7 +29,7 @@
       path: "{{ dest }}/{{app_basename}}"
       state: absent
     when: installer_type == 'app' or installer_type == 'zip' or installer_type == 'compressed_archive'
-  become: yes
+  become: True
 
 - block:
     # Actions for `installer` type
@@ -79,8 +79,8 @@
     when:
       - archive_extension != '.dmg'
       - (installer_type == 'zip' or installer_type == 'compressed_archive')
-    ignore_errors: yes
-    become: yes
+    ignore_errors: True
+    become: True
   # end block
   when: installer_type == 'app' or installer_type == 'zip' or installer_type == 'compressed_archive'
 
@@ -94,10 +94,10 @@
   ## http://help.preyproject.com/article/188-prey-unattended-install-for-computers
   - name: Run install of "{{ app_name }}.pkg"
     shell: "{{ env }} installer -package '{{ pkg_path | expanduser }}' -target /"
-    ignore_errors: yes
+    ignore_errors: True
   # end block
   when: installer_type == 'pkg' or installer_type == 'pkgonly'
-  become: yes
+  become: True
 
 # this task cannot be escalated to super-user or target-user because it will trigger a GUI interactive installation process
 # so it is valid only if the role is used to install apps on behalf of the same user that is running the deployment
@@ -107,7 +107,7 @@
 
   - name: Run interactive install of "{{ app_name }}"
     shell: "{{ env }} open '{{ pkg_path | expanduser }}'"
-    ignore_errors: yes
+    ignore_errors: True
   # end block
   when: installer_type == 'installer'
 
@@ -118,7 +118,7 @@
   command: "hdiutil detach '{{ mount_path | expanduser }}'"
   when: archive_extension == '.dmg'
   register: unmount_result
-  changed_when: no
+  changed_when: False
   retries: 20
   delay: 10
   until: unmount_result is not failed

--- a/tasks/archive-install.yml
+++ b/tasks/archive-install.yml
@@ -22,21 +22,17 @@
   when: archive_extension == '.dmg' and mounted is defined and not mounted.stat.exists
   changed_when: false
 
-
 - block:
+  # we want the super-user to remvoe the existing app in case it was installed by another user
   - name: Remove existing app if present
     file:
       path: "{{ dest }}/{{app_basename}}"
       state: absent
-    become: yes
-
-  - name: Copy '{{ app_name }}' app to '{{ dest }}'
-    command: "cp -R '{{ mount_path }}/{{ app_basename }}' '{{ dest }}/'"
-    become: yes
-
-  when: installer_type == 'app' # end block
+    when: installer_type == 'app' or installer_type == 'zip' or installer_type == 'compressed_archive'
+  become: yes
 
 - block:
+    # Actions for `installer` type
   - fail:
       msg: "'exec_name' (installer name), must be set to the installer path"
     when: installer_name == ''
@@ -45,7 +41,6 @@
     set_fact:
       pkg_path: "{{ mount_path }}/{{ installer_name }}"
     when: installer_name != ''
-
   when: installer_type == 'installer' # end block
 
 - block:
@@ -59,18 +54,45 @@
     set_fact:
       pkg_path: "{{ mount_path }}/{{ installer_name }}"
     when: installer_name != ''
-
   when: installer_type == 'pkg' # end block
 
-## Note: env allow to pass variables like API_key for
-##      http://help.preyproject.com/article/188-prey-unattended-install-for-computers
+- block:
+    # we want that the installed app will belong to the target-user
+    #
+    # Actions for `app` `zip` and `compressed installer types
+  - name: Copy '{{ app_name }}' app to '{{ dest }}'
+    command: "cp -R '{{ mount_path }}/{{ app_basename }}' '{{ dest }}/'"
+    when:
+      - archive_extension == '.dmg'
+      - installer_type == 'app'
 
-- name: Run install of "{{ app_name }}.pkg"
-  shell: "{{ env }} installer -package '{{ pkg_path | expanduser }}' -target /"
-  when: installer_type == 'pkg' or installer_type == 'pkgonly'
-  become: true
-  ignore_errors: true
+  # if the archive is a compressed file the app will be extrated directly to it's destination
+  - name: Extract '{{ app_name }}' to {{ dest }}'
+    unarchive:
+      src: "{{ pkg_path }}"
+      dest: "{{ dest }}"
+    when:
+      - archive_extension != '.dmg'
+      - (installer_type == 'zip' or installer_type == 'compressed_archive')
+    ignore_errors: true
+  when: installer_type != 'pkg' # end block
+  become: "{{ (target_user_id != ansible_user_id) | bool }}"
+  become_user: "{{ target_user_id }}"
 
+- block:
+  # This block is run as super-user because pkg installation frequently contain
+  # system components that require the higher provileges to be installed in system paths
+  #
+  ## Note: env allow to pass variables like API_key for
+  ##      http://help.preyproject.com/article/188-prey-unattended-install-for-computers
+  - name: Run install of "{{ app_name }}.pkg"
+    shell: "{{ env }} installer -package '{{ pkg_path | expanduser }}' -target /"
+    when: installer_type == 'pkg' or installer_type == 'pkgonly'
+    ignore_errors: true
+  become: yes
+
+# this task cannot be escalated to super-user or target-user because it will trigger a GUI interactive installation process
+# so it is valid only if the role is used to install apps on behalf of the same user that is running the deployment
 - name: Run interactive install of "{{ app_name }}"
   shell: "{{ env }} open '{{ pkg_path | expanduser }}'"
   when: installer_type == 'installer'
@@ -89,12 +111,3 @@
   until: unmount_result is not failed
   async: 1000
   poll: 0
-
-# if the archive is a compressed file the app will be extrated directly to it's destination
-- name: Extract '{{ app_name }}' to {{ dest }}'
-  unarchive:
-    src: "{{ pkg_path }}"
-    dest: "{{ dest }}"
-  when: archive_extension != '.dmg' and installer_type == 'zip' or installer_type == 'compressed_archive'
-  become: yes
-  ignore_errors: true

--- a/tasks/archive-install.yml
+++ b/tasks/archive-install.yml
@@ -67,26 +67,29 @@
     when:
       - archive_extension == '.dmg'
       - installer_type == 'app'
+    become: "{{ (target_user_id != ansible_user_id) | bool }}"
+    become_user: "{{ target_user_id }}"
 
   # if the archive is a compressed file the app will be extrated directly to it's destination
   - name: Extract '{{ app_name }}' to {{ dest }}'
     unarchive:
       src: "{{ pkg_path }}"
       dest: "{{ dest }}"
+      owner: "{{ target_user_id }}"
     when:
       - archive_extension != '.dmg'
       - (installer_type == 'zip' or installer_type == 'compressed_archive')
     ignore_errors: yes
+    become: yes
   # end block
-  when: installer_type == 'app' or installer_type == 'zip 'and installer_type == 'compressed_archive'
-  become: "{{ (target_user_id != ansible_user_id) | bool }}"
-  become_user: "{{ target_user_id }}"
+  when: installer_type == 'app' or installer_type == 'zip' or installer_type == 'compressed_archive'
+
 
 - block:
   # This block is run as super-user because pkg installation frequently contain
   # system components that require the higher provileges to be installed in system paths
   - debug:
-      msg: "This app will be installed as the user `{{ become_user }}`"
+      msg: "This app will be installed with super-user privileges"
   ## Note: env allow to pass variables like API_key for
   ## http://help.preyproject.com/article/188-prey-unattended-install-for-computers
   - name: Run install of "{{ app_name }}.pkg"
@@ -100,7 +103,7 @@
 # so it is valid only if the role is used to install apps on behalf of the same user that is running the deployment
 - block:
   - debug:
-      msg: "This app will be installed as the user `{{ ansinle_user_id }}`"
+      msg: "This app will be installed as the user `{{ ansible_user_id }}`"
 
   - name: Run interactive install of "{{ app_name }}"
     shell: "{{ env }} open '{{ pkg_path | expanduser }}'"

--- a/tasks/darwin.yml
+++ b/tasks/darwin.yml
@@ -34,7 +34,7 @@
             app_url={{ item.u }}
             app_archive={{ item.f | default(item.u | basename) }}
             archive_extension={{ app_archive|default('') | splitext |  last }}
-            validate_certs={{ item.v | default(true) }}
+            validate_certs={{ item.v | default(True) }}
             checksum={{ item.s | default('')}}
             app_name={{ item.n }}
             installer_type={{ item.t|default('app') }}

--- a/tasks/install-app.yml
+++ b/tasks/install-app.yml
@@ -65,7 +65,7 @@
 
     - name: Versions comparison
       debug:
-        var: "{{ version | version( currentversion, '>') }}"
+        var: "{{ version is version( currentversion, '>') }}"
   # end block
   when:
     - verbose|bool

--- a/tasks/install-app.yml
+++ b/tasks/install-app.yml
@@ -4,14 +4,14 @@
 
 ## Note: some app are not installing here
 
-- name: Define Package Path
-  set_fact:
-    pkg_path: "{{ install_archives | expanduser  }}/{{ app_archive }}"
-    
 - name: Define app name to '{{ app_name }}.app'
   set_fact:
     app_basename: "{{ app_name }}.app"
   when: app_name is defined and app_name != ''
+
+- name: Define Package Path "{{ install_archives | expanduser  }}/{{ app_archive }}"
+  set_fact:
+    pkg_path: "{{ install_archives | expanduser  }}/{{ app_archive }}"
 
 - name: Define installer name to '{{ installer_name }}'
   set_fact:
@@ -25,15 +25,14 @@
   when: version != ''
 
 - debug:
-    msg: "Install Archive: {{install_archives}}'"
+    msg: "Archives Path: {{install_archives}}'"
   when: verbose|bool
 - debug:
-    msg: "App Name: {{app_archive}}'"
+    msg: "Package Name: {{app_archive}}'"
   when: verbose|bool
 - debug:
     msg: "Package Path: {{pkg_path}}'"
   when: verbose|bool
-
 
 - debug:
     msg: "The desired version for '{{ app_name }}' is '{{ version }}'"
@@ -56,18 +55,21 @@
   when: version !='' and app is defined and app.stat.exists
 
 - block:
-    - name: debugging info
+    - name: Required version
       debug:
         var: version
 
-    - debug:
+    - name: Current version
+      debug:
         var: currentversion|default('')
-      when: app.stat.exists is defined and app.stat.exists and versioncmd is defined and versioncmd != ""
 
-    - debug:
+    - name: Versions comparison
+      debug:
         var: "{{ version | version( currentversion, '>') }}"
-      when: app.stat.exists is defined and app.stat.exists and versioncmd is defined and versioncmd != ""
-  when: verbose|bool
+  # end block
+  when:
+    - verbose|bool
+    - app.stat.exists is defined and app.stat.exist
 
 - name: Already up-to-date!
   debug:

--- a/tasks/install-app.yml
+++ b/tasks/install-app.yml
@@ -25,13 +25,13 @@
   when: version != ''
 
 - debug:
-    msg: "Archives Path: {{install_archives}}'"
+    msg: "Archives Path: {{ install_archives }}'"
   when: verbose|bool
 - debug:
-    msg: "Package Name: {{app_archive}}'"
+    msg: "Package Name: {{ app_archive }}'"
   when: verbose|bool
 - debug:
-    msg: "Package Path: {{pkg_path}}'"
+    msg: "Package Path: {{ pkg_path }}'"
   when: verbose|bool
 
 - debug:
@@ -47,7 +47,7 @@
   when: version != '' and app.stat.exists is defined and not app.stat.exists
 
 - include: "macos-apps-version.yml
-            version_app_path='{{ dest }}/{{app_basename}}'
+            version_app_path='{{ dest }}/{{ app_basename }}'
             version_app_cmd='{{ versioncmd }}'
             version_app_default='0.01'
             version_app_plist_tag='{{ plist_tag }}'

--- a/tasks/install-app.yml
+++ b/tasks/install-app.yml
@@ -69,7 +69,7 @@
   # end block
   when:
     - verbose|bool
-    - app.stat.exists is defined and app.stat.exist
+    - version !='' and app is defined and app.stat.exists
 
 - name: Already up-to-date!
   debug:

--- a/tasks/macos-apps-version.yml
+++ b/tasks/macos-apps-version.yml
@@ -30,8 +30,8 @@
 - name: Get current App version of {{ version_app_path }}
   shell: "{{ version_app_cmd }}"
   register: version_app_shell
-  changed_when: no
-  ignore_errors: yes
+  changed_when: False
+  ignore_errors: True
   when: app.stat.exists and version_app_cmd != ''
 
 - name: The current App version is '{{ version_app_shell.stdout }}'

--- a/tasks/macos-apps-version.yml
+++ b/tasks/macos-apps-version.yml
@@ -30,8 +30,8 @@
 - name: Get current App version of {{ version_app_path }}
   shell: "{{ version_app_cmd }}"
   register: version_app_shell
-  changed_when: false
-  ignore_errors: true
+  changed_when: no
+  ignore_errors: yes
   when: app.stat.exists and version_app_cmd != ''
 
 - name: The current App version is '{{ version_app_shell.stdout }}'

--- a/tasks/travis.yml
+++ b/tasks/travis.yml
@@ -5,5 +5,5 @@
   set_fact:
     pip_path: /usr/local/bin/pip
 ## this is not passed into ansible on osx
-#  when: ansible_env['TRAVIS'] is defined and ansible_env['TRAVIS'] == 'true'
+#  when: ansible_env['TRAVIS'] is defined and ansible_env['TRAVIS'] == 'True'
   when: ansible_env['SUDO_USER'] is defined and ansible_env['SUDO_USER'] == 'travis'

--- a/test/integration/default/default.yml
+++ b/test/integration/default/default.yml
@@ -2,11 +2,11 @@
 
 - hosts: all
   vars:
-    verbose: true
+    verbose: yes
     macos_apps_install_list:
       - { u: 'https://download.mozilla.org/?product=firefox-69.0-SSL&os=osx&lang=en-US',
           f: 'firefox-69.0-SSL-en-US.dmg',
-          v: true,
+          v: yes,
           s: 'bfa9ae88ac188276c9ed17ff2e5f6e2440d6513710a32002d51be9b620d3e71c',
           n: 'Firefox',
           t: 'app',
@@ -14,27 +14,27 @@
         }
       - { u: 'https://download.mozilla.org/?product=thunderbird-60.7.2-SSL&os=osx&lang=en-US',
           f: 'thunderbird-60.7.2-SSL-fr.dmg',
-          v: true,
+          v: yes,
           s: '66d937ee3db5d06d7982046e24f9340d60612889c15ef98b224726824376f910',
           n: 'Thunderbird',
           t: 'app',
           version: '60.7.2'
         }
 #      - { u: 'https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg',
-#          v: true, s: '64d20453923386f48bffe1d7597036ed92e0121f88adc74a59a7ffb52f226bbc',
+#          v: yes, s: '64d20453923386f48bffe1d7597036ed92e0121f88adc74a59a7ffb52f226bbc',
 #          n: 'Google Chrome',
 #          t: 'app',
 #          version: '76.0'
 #        }
 #      - { u: "https://download.documentfoundation.org/libreoffice/stable/6.2.4/mac/x86_64/LibreOffice_6.2.4_MacOS_x86-64.dmg",
-#          v: true,
+#          v: yes,
 #          s: 'xxx',
 #          n: 'LibreOffice',
 #          t: 'app',
 #          version: '6.2.4'
 #        }
 #      - { u: 'http://get.videolan.org/vlc/3.0.7.1/macosx/vlc-3.0.7.1.dmg',
-#          v: false,
+#          v: no,
 #          s: 'xxx',
 #          n: 'VLC',
 #          t: 'app',
@@ -42,13 +42,13 @@
 #          version: '3.0.7.1'
 #        }
 #      - { u: 'https://dl.dropbox.com/u/1140644/clipmenu/ClipMenu_0.4.3.dmg',
-#          v: true, s: 'd0d7ca6c23f51b2dfe78c7bb40bf2f212c21b3304b3eacde86112d8ef3e6bfb9',
+#          v: yes, s: 'd0d7ca6c23f51b2dfe78c7bb40bf2f212c21b3304b3eacde86112d8ef3e6bfb9',
 #          n: 'ClipMenu',
 #          t: 'app',
 #          version: '0.4.3'
 #        }
 #      - { u: 'https://download.virtualbox.org/virtualbox/6.0.8/VirtualBox-6.0.8-130520-OSX.dmg',
-#          v: false,
+#          v: no,
 #          s: '8e3ed48842821adba3cb48c37a2ffea8e1446ea7a99446df6a42c681720a90dd',
 #          n: 'VirtualBox',
 #          t: 'pkg',
@@ -57,7 +57,7 @@
 ## FIXME! requires recent apple/openssl to support tls1.2 only server
 ##  https://github.com/jhaals/ansible-vault/issues/15
 #      - { u: 'https://releases.hashicorp.com/vagrant/2.2.5/vagrant_2.2.5_x86_64.dmg',
-#          v: false,
+#          v: no,
 #          s: '07f7be3a457a8422d576e6371c8499fbdea411b02aecc7ea3c5258494514c5f2',
 #          n: 'Vagrant',
 #          t: 'pkg',
@@ -67,7 +67,7 @@
 #        }
 #      - { u: 'https://www.parallels.com/directdownload/pd13/',
 #          f: 'ParallelsDesktop-13.2.0-43213.dmg',
-#          v: true,
+#          v: yes,
 #          s: 'xxx',
 #          n: 'Parallels Desktop',
 #          t: 'app',
@@ -77,7 +77,7 @@
 #          to: '/Applications/Parallels Desktop.app'
 #        }
 #      - { u: 'https://dl.bintray.com/xquartz/downloads/XQuartz-2.7.11.dmg',
-#          v: true,
+#          v: yes,
 #          s: '32e50e8f1e21542b847041711039fa78d44febfed466f834a9281c44d75cd6c3',
 #          n: 'XQuartz',
 #          t: 'pkg',
@@ -87,7 +87,7 @@
 #        }
 #      - { u: 'https://1.eu.dl.wireshark.org/osx/Wireshark%203.0.2%20Intel%2064.dmg',
 #          f: 'Wireshark-3.0.2-Intel-64.dmg',
-#          v: true,
+#          v: yes,
 #          s: '61f500c923b729be56b4bf453c2fca865cd921b8cc153da8a79d45a3f932bdd3',
 #          n: 'Wireshark',
 #          t: 'pkg',
@@ -95,7 +95,7 @@
 #          exec_name: 'Wireshark 3.0.2 Intel 64.pkg'
 #        }
 #      - { u: 'https://download.docker.com/mac/stable/Docker.dmg',
-#          v: true,
+#          v: yes,
 #          s: 'xxx',
 #          n: 'Docker',
 #          t: 'app',
@@ -106,7 +106,7 @@
 #        }
   ## http://help.preyproject.com/article/188-prey-unattended-install-for-computers
       - { u: 'https://github.com/prey/prey-node-client/releases/download/v1.8.3/prey-mac-1.8.3-x64.pkg',
-          v: false,
+          v: no,
           s: '112c1b38d5415fc86076783885c791eaa02dbce3051e8a7ba5c10bae8b980164',
           n: 'Prey',
           t: 'pkgonly',
@@ -117,7 +117,7 @@
         }
   ## osxfuse is required for veracrypt
       - { u: 'https://github.com/osxfuse/osxfuse/releases/download/osxfuse-3.9.2/osxfuse-3.9.2.dmg',
-          v: true,
+          v: yes,
           s: 'de45388f6aceb547f08112e24f2ed49a2160725ed4590adcc8488a5d5d3f0067',
           n: 'FUSE',
           t: 'pkg',
@@ -128,7 +128,7 @@
           versioncmd: '/usr/libexec/PlistBuddy -c "print :CFBundleVersion" "/Library/Filesystems/osxfuse.fs/Contents/Info.plist"'
         }
       - { u: 'https://launchpad.net/veracrypt/trunk/1.23/+download/VeraCrypt_1.23.dmg',
-          v: true,
+          v: yes,
           s: '8c5ba5e8a19de5a33461f3cd84617140736d7cb38e306d0ac4b1c058940227f3',
           n: 'VeraCrypt',
           t: 'pkg',
@@ -137,7 +137,7 @@
           exec_name: 'VeraCrypt_Installer.pkg'
         }
       - { u: 'https://github.com/google/santa/releases/download/0.9.31/santa-0.9.31.dmg',
-          v: false,
+          v: no,
           s: '6843afe8a924c0a9498d07d40acac4d5daafa0177dbf70181bc6be97e0067645',
           n: 'santa-0.9.31',
           t: 'pkg',
@@ -146,7 +146,7 @@
           to: '/usr/local/bin/santactl'
         }
       - { u: 'https://pkg.osquery.io/darwin/osquery-3.3.2.pkg',
-          v: true,
+          v: yes,
           s: '6ac1baa9bd13fcf3bd4c1b20a020479d51e26a8ec81783be7a8692d2c4a9926a',
           n: 'osquery',
           t: 'pkgonly',
@@ -155,11 +155,11 @@
           to: '/usr/local/bin/osqueryi'
         }
 #      - { u: 'https://releases.gpgtools.org/GPG_Suite-2018.5.dmg',
-#          v: false,
+#          v: no,
 #          s: 'c66ecf48ccf709f704f02097cf9d68ba97b0efba24f7a0b7b46adfd1133cb86a'
 #        }
       - { u: 'https://packages.chef.io/files/stable/inspec/4.18.51/mac_os_x/10.15/inspec-4.18.51-1.dmg',
-          v: true,
+          v: yes,
           s: 'efbc8949c34ce12cd0f87bbee57b7535f0f3bc1705c47ac4c490909ec85e3aa5',
           n: 'inspec',
           t: 'pkg',
@@ -171,7 +171,7 @@
         }
 #        https://distfiles.macports.org/MacPorts/MacPorts-2.5.4-10.14-Mojave.pkg
       - { u: 'https://distfiles.macports.org/MacPorts/MacPorts-2.5.4-10.13-HighSierra.pkg',
-          v: false,
+          v: no,
           s: '07c5c8a62e61c5cb8506cd3b9784dbb06a8fa48c3c6f1e3954f96a82fcb3b77c',
           n: 'MacPorts',
           t: 'pkgonly',
@@ -180,7 +180,7 @@
         }
 #      - { u: '',
 #          f: '',
-#          v: true,
+#          v: yes,
 #          s: 'aaaa',
 #          n: '',
 #          t: 'app',

--- a/test/integration/default/default.yml
+++ b/test/integration/default/default.yml
@@ -2,11 +2,11 @@
 
 - hosts: all
   vars:
-    verbose: yes
+    verbose: True
     macos_apps_install_list:
       - { u: 'https://download.mozilla.org/?product=firefox-69.0-SSL&os=osx&lang=en-US',
           f: 'firefox-69.0-SSL-en-US.dmg',
-          v: yes,
+          v: True,
           s: 'bfa9ae88ac188276c9ed17ff2e5f6e2440d6513710a32002d51be9b620d3e71c',
           n: 'Firefox',
           t: 'app',
@@ -14,27 +14,27 @@
         }
       - { u: 'https://download.mozilla.org/?product=thunderbird-60.7.2-SSL&os=osx&lang=en-US',
           f: 'thunderbird-60.7.2-SSL-fr.dmg',
-          v: yes,
+          v: True,
           s: '66d937ee3db5d06d7982046e24f9340d60612889c15ef98b224726824376f910',
           n: 'Thunderbird',
           t: 'app',
           version: '60.7.2'
         }
 #      - { u: 'https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg',
-#          v: yes, s: '64d20453923386f48bffe1d7597036ed92e0121f88adc74a59a7ffb52f226bbc',
+#          v: True, s: '64d20453923386f48bffe1d7597036ed92e0121f88adc74a59a7ffb52f226bbc',
 #          n: 'Google Chrome',
 #          t: 'app',
 #          version: '76.0'
 #        }
 #      - { u: "https://download.documentfoundation.org/libreoffice/stable/6.2.4/mac/x86_64/LibreOffice_6.2.4_MacOS_x86-64.dmg",
-#          v: yes,
+#          v: True,
 #          s: 'xxx',
 #          n: 'LibreOffice',
 #          t: 'app',
 #          version: '6.2.4'
 #        }
 #      - { u: 'http://get.videolan.org/vlc/3.0.7.1/macosx/vlc-3.0.7.1.dmg',
-#          v: no,
+#          v: False,
 #          s: 'xxx',
 #          n: 'VLC',
 #          t: 'app',
@@ -42,13 +42,13 @@
 #          version: '3.0.7.1'
 #        }
 #      - { u: 'https://dl.dropbox.com/u/1140644/clipmenu/ClipMenu_0.4.3.dmg',
-#          v: yes, s: 'd0d7ca6c23f51b2dfe78c7bb40bf2f212c21b3304b3eacde86112d8ef3e6bfb9',
+#          v: True, s: 'd0d7ca6c23f51b2dfe78c7bb40bf2f212c21b3304b3eacde86112d8ef3e6bfb9',
 #          n: 'ClipMenu',
 #          t: 'app',
 #          version: '0.4.3'
 #        }
 #      - { u: 'https://download.virtualbox.org/virtualbox/6.0.8/VirtualBox-6.0.8-130520-OSX.dmg',
-#          v: no,
+#          v: False,
 #          s: '8e3ed48842821adba3cb48c37a2ffea8e1446ea7a99446df6a42c681720a90dd',
 #          n: 'VirtualBox',
 #          t: 'pkg',
@@ -57,7 +57,7 @@
 ## FIXME! requires recent apple/openssl to support tls1.2 only server
 ##  https://github.com/jhaals/ansible-vault/issues/15
 #      - { u: 'https://releases.hashicorp.com/vagrant/2.2.5/vagrant_2.2.5_x86_64.dmg',
-#          v: no,
+#          v: False,
 #          s: '07f7be3a457a8422d576e6371c8499fbdea411b02aecc7ea3c5258494514c5f2',
 #          n: 'Vagrant',
 #          t: 'pkg',
@@ -67,7 +67,7 @@
 #        }
 #      - { u: 'https://www.parallels.com/directdownload/pd13/',
 #          f: 'ParallelsDesktop-13.2.0-43213.dmg',
-#          v: yes,
+#          v: True,
 #          s: 'xxx',
 #          n: 'Parallels Desktop',
 #          t: 'app',
@@ -77,7 +77,7 @@
 #          to: '/Applications/Parallels Desktop.app'
 #        }
 #      - { u: 'https://dl.bintray.com/xquartz/downloads/XQuartz-2.7.11.dmg',
-#          v: yes,
+#          v: True,
 #          s: '32e50e8f1e21542b847041711039fa78d44febfed466f834a9281c44d75cd6c3',
 #          n: 'XQuartz',
 #          t: 'pkg',
@@ -87,7 +87,7 @@
 #        }
 #      - { u: 'https://1.eu.dl.wireshark.org/osx/Wireshark%203.0.2%20Intel%2064.dmg',
 #          f: 'Wireshark-3.0.2-Intel-64.dmg',
-#          v: yes,
+#          v: True,
 #          s: '61f500c923b729be56b4bf453c2fca865cd921b8cc153da8a79d45a3f932bdd3',
 #          n: 'Wireshark',
 #          t: 'pkg',
@@ -95,7 +95,7 @@
 #          exec_name: 'Wireshark 3.0.2 Intel 64.pkg'
 #        }
 #      - { u: 'https://download.docker.com/mac/stable/Docker.dmg',
-#          v: yes,
+#          v: True,
 #          s: 'xxx',
 #          n: 'Docker',
 #          t: 'app',
@@ -106,7 +106,7 @@
 #        }
   ## http://help.preyproject.com/article/188-prey-unattended-install-for-computers
       - { u: 'https://github.com/prey/prey-node-client/releases/download/v1.8.3/prey-mac-1.8.3-x64.pkg',
-          v: no,
+          v: False,
           s: '112c1b38d5415fc86076783885c791eaa02dbce3051e8a7ba5c10bae8b980164',
           n: 'Prey',
           t: 'pkgonly',
@@ -117,7 +117,7 @@
         }
   ## osxfuse is required for veracrypt
       - { u: 'https://github.com/osxfuse/osxfuse/releases/download/osxfuse-3.9.2/osxfuse-3.9.2.dmg',
-          v: yes,
+          v: True,
           s: 'de45388f6aceb547f08112e24f2ed49a2160725ed4590adcc8488a5d5d3f0067',
           n: 'FUSE',
           t: 'pkg',
@@ -128,7 +128,7 @@
           versioncmd: '/usr/libexec/PlistBuddy -c "print :CFBundleVersion" "/Library/Filesystems/osxfuse.fs/Contents/Info.plist"'
         }
       - { u: 'https://launchpad.net/veracrypt/trunk/1.23/+download/VeraCrypt_1.23.dmg',
-          v: yes,
+          v: True,
           s: '8c5ba5e8a19de5a33461f3cd84617140736d7cb38e306d0ac4b1c058940227f3',
           n: 'VeraCrypt',
           t: 'pkg',
@@ -137,7 +137,7 @@
           exec_name: 'VeraCrypt_Installer.pkg'
         }
       - { u: 'https://github.com/google/santa/releases/download/0.9.31/santa-0.9.31.dmg',
-          v: no,
+          v: False,
           s: '6843afe8a924c0a9498d07d40acac4d5daafa0177dbf70181bc6be97e0067645',
           n: 'santa-0.9.31',
           t: 'pkg',
@@ -146,7 +146,7 @@
           to: '/usr/local/bin/santactl'
         }
       - { u: 'https://pkg.osquery.io/darwin/osquery-3.3.2.pkg',
-          v: yes,
+          v: True,
           s: '6ac1baa9bd13fcf3bd4c1b20a020479d51e26a8ec81783be7a8692d2c4a9926a',
           n: 'osquery',
           t: 'pkgonly',
@@ -155,11 +155,11 @@
           to: '/usr/local/bin/osqueryi'
         }
 #      - { u: 'https://releases.gpgtools.org/GPG_Suite-2018.5.dmg',
-#          v: no,
+#          v: False,
 #          s: 'c66ecf48ccf709f704f02097cf9d68ba97b0efba24f7a0b7b46adfd1133cb86a'
 #        }
       - { u: 'https://packages.chef.io/files/stable/inspec/4.18.51/mac_os_x/10.15/inspec-4.18.51-1.dmg',
-          v: yes,
+          v: True,
           s: 'efbc8949c34ce12cd0f87bbee57b7535f0f3bc1705c47ac4c490909ec85e3aa5',
           n: 'inspec',
           t: 'pkg',
@@ -171,7 +171,7 @@
         }
 #        https://distfiles.macports.org/MacPorts/MacPorts-2.5.4-10.14-Mojave.pkg
       - { u: 'https://distfiles.macports.org/MacPorts/MacPorts-2.5.4-10.13-HighSierra.pkg',
-          v: no,
+          v: False,
           s: '07c5c8a62e61c5cb8506cd3b9784dbb06a8fa48c3c6f1e3954f96a82fcb3b77c',
           n: 'MacPorts',
           t: 'pkgonly',
@@ -180,7 +180,7 @@
         }
 #      - { u: '',
 #          f: '',
-#          v: yes,
+#          v: True,
 #          s: 'aaaa',
 #          n: '',
 #          t: 'app',

--- a/test/integration/default/target-user-requirements.yml
+++ b/test/integration/default/target-user-requirements.yml
@@ -1,4 +1,0 @@
----
-- name: marcomc.macos-new-user
-  src: https://github.com/marcomc/ansible-role-macos-new-user.git
-  version: 'master'

--- a/test/integration/default/target-user-requirements.yml
+++ b/test/integration/default/target-user-requirements.yml
@@ -1,0 +1,4 @@
+---
+- name: marcomc.macos-new-user
+  src: https://github.com/marcomc/ansible-role-macos-new-user.git
+  version: 'master'

--- a/test/integration/default/target-user.yml
+++ b/test/integration/default/target-user.yml
@@ -1,0 +1,194 @@
+---
+
+- hosts: all
+  vars:
+    verbose: True
+    macos_apps_install_list:
+      - { u: 'https://download.mozilla.org/?product=firefox-69.0-SSL&os=osx&lang=en-US',
+          f: 'firefox-69.0-SSL-en-US.dmg',
+          v: True,
+          s: 'bfa9ae88ac188276c9ed17ff2e5f6e2440d6513710a32002d51be9b620d3e71c',
+          n: 'Firefox',
+          t: 'app',
+          version: '69.0'
+        }
+      - { u: 'https://download.mozilla.org/?product=thunderbird-60.7.2-SSL&os=osx&lang=en-US',
+          f: 'thunderbird-60.7.2-SSL-fr.dmg',
+          v: True,
+          s: '66d937ee3db5d06d7982046e24f9340d60612889c15ef98b224726824376f910',
+          n: 'Thunderbird',
+          t: 'app',
+          version: '60.7.2'
+        }
+#      - { u: 'https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg',
+#          v: True, s: '64d20453923386f48bffe1d7597036ed92e0121f88adc74a59a7ffb52f226bbc',
+#          n: 'Google Chrome',
+#          t: 'app',
+#          version: '76.0'
+#        }
+#      - { u: "https://download.documentfoundation.org/libreoffice/stable/6.2.4/mac/x86_64/LibreOffice_6.2.4_MacOS_x86-64.dmg",
+#          v: True,
+#          s: 'xxx',
+#          n: 'LibreOffice',
+#          t: 'app',
+#          version: '6.2.4'
+#        }
+#      - { u: 'http://get.videolan.org/vlc/3.0.7.1/macosx/vlc-3.0.7.1.dmg',
+#          v: False,
+#          s: 'xxx',
+#          n: 'VLC',
+#          t: 'app',
+#          m: '/Volumes/vlc-3.0.7.1',
+#          version: '3.0.7.1'
+#        }
+#      - { u: 'https://dl.dropbox.com/u/1140644/clipmenu/ClipMenu_0.4.3.dmg',
+#          v: True, s: 'd0d7ca6c23f51b2dfe78c7bb40bf2f212c21b3304b3eacde86112d8ef3e6bfb9',
+#          n: 'ClipMenu',
+#          t: 'app',
+#          version: '0.4.3'
+#        }
+#      - { u: 'https://download.virtualbox.org/virtualbox/6.0.8/VirtualBox-6.0.8-130520-OSX.dmg',
+#          v: False,
+#          s: '8e3ed48842821adba3cb48c37a2ffea8e1446ea7a99446df6a42c681720a90dd',
+#          n: 'VirtualBox',
+#          t: 'pkg',
+#          version: '6.0.8'
+#        }
+## FIXME! requires recent apple/openssl to support tls1.2 only server
+##  https://github.com/jhaals/ansible-vault/issues/15
+#      - { u: 'https://releases.hashicorp.com/vagrant/2.2.5/vagrant_2.2.5_x86_64.dmg',
+#          v: False,
+#          s: '07f7be3a457a8422d576e6371c8499fbdea411b02aecc7ea3c5258494514c5f2',
+#          n: 'Vagrant',
+#          t: 'pkg',
+#          version: '2.2.5',
+#          versioncmd: '/opt/vagrant/bin/vagrant --version | sed "s@Vagrant @@;"',
+#          to: '/opt/vagrant/bin/vagrant'
+#        }
+#      - { u: 'https://www.parallels.com/directdownload/pd13/',
+#          f: 'ParallelsDesktop-13.2.0-43213.dmg',
+#          v: True,
+#          s: 'xxx',
+#          n: 'Parallels Desktop',
+#          t: 'app',
+#          m: '/Volumes/Parallels Desktop 13',
+#          version: '13.2.0',
+#          versioncmd: '',
+#          to: '/Applications/Parallels Desktop.app'
+#        }
+#      - { u: 'https://dl.bintray.com/xquartz/downloads/XQuartz-2.7.11.dmg',
+#          v: True,
+#          s: '32e50e8f1e21542b847041711039fa78d44febfed466f834a9281c44d75cd6c3',
+#          n: 'XQuartz',
+#          t: 'pkg',
+#          m: '/Volumes/XQuartz-2.7.11',
+#          version: '2.7.11',
+#          to: '/Applications/Utilities/XQuartz.app'
+#        }
+#      - { u: 'https://1.eu.dl.wireshark.org/osx/Wireshark%203.0.2%20Intel%2064.dmg',
+#          f: 'Wireshark-3.0.2-Intel-64.dmg',
+#          v: True,
+#          s: '61f500c923b729be56b4bf453c2fca865cd921b8cc153da8a79d45a3f932bdd3',
+#          n: 'Wireshark',
+#          t: 'pkg',
+#          version: '3.0.2',
+#          exec_name: 'Wireshark 3.0.2 Intel 64.pkg'
+#        }
+#      - { u: 'https://download.docker.com/mac/stable/Docker.dmg',
+#          v: True,
+#          s: 'xxx',
+#          n: 'Docker',
+#          t: 'app',
+#          m: '/Volumes/Docker',
+#          version: '17.09.1',
+#          versioncmd: '/usr/libexec/PlistBuddy -c "print :CFBundleShortVersionString" /Applications/Docker.app/Contents/Info.plist',
+#          to: '/Applications/Docker.app'
+#        }
+  ## http://help.preyproject.com/article/188-prey-unattended-install-for-computers
+      - { u: 'https://github.com/prey/prey-node-client/releases/download/v1.8.3/prey-mac-1.8.3-x64.pkg',
+          v: False,
+          s: '112c1b38d5415fc86076783885c791eaa02dbce3051e8a7ba5c10bae8b980164',
+          n: 'Prey',
+          t: 'pkgonly',
+          version: '1.8.3',
+          env: "env API_KEY={{ prey_apikey | default('') }}",
+          to: '/usr/local/lib/prey/current/bin/prey',
+          versioncmd: '/usr/local/lib/prey/current/bin/prey --version'
+        }
+  ## osxfuse is required for veracrypt
+      - { u: 'https://github.com/osxfuse/osxfuse/releases/download/osxfuse-3.9.2/osxfuse-3.9.2.dmg',
+          v: True,
+          s: 'de45388f6aceb547f08112e24f2ed49a2160725ed4590adcc8488a5d5d3f0067',
+          n: 'FUSE',
+          t: 'pkg',
+          m: '/Volumes/FUSE for macOS',
+          version: '3.9.2',
+          to: '/Library/Filesystems/osxfuse.fs',
+          exec_name: 'FUSE for macOS.pkg',
+          versioncmd: '/usr/libexec/PlistBuddy -c "print :CFBundleVersion" "/Library/Filesystems/osxfuse.fs/Contents/Info.plist"'
+        }
+      - { u: 'https://launchpad.net/veracrypt/trunk/1.23/+download/VeraCrypt_1.23.dmg',
+          v: True,
+          s: '8c5ba5e8a19de5a33461f3cd84617140736d7cb38e306d0ac4b1c058940227f3',
+          n: 'VeraCrypt',
+          t: 'pkg',
+          m: '/Volumes/VeraCrypt for OSX',
+          version: '1.23',
+          exec_name: 'VeraCrypt_Installer.pkg'
+        }
+      - { u: 'https://github.com/google/santa/releases/download/0.9.31/santa-0.9.31.dmg',
+          v: False,
+          s: '6843afe8a924c0a9498d07d40acac4d5daafa0177dbf70181bc6be97e0067645',
+          n: 'santa-0.9.31',
+          t: 'pkg',
+          version: '0.9.31',
+          versioncmd: '/usr/local/bin/santactl version | sed "1 s/.*| //;q"',
+          to: '/usr/local/bin/santactl'
+        }
+      - { u: 'https://pkg.osquery.io/darwin/osquery-3.3.2.pkg',
+          v: True,
+          s: '6ac1baa9bd13fcf3bd4c1b20a020479d51e26a8ec81783be7a8692d2c4a9926a',
+          n: 'osquery',
+          t: 'pkgonly',
+          version: '3.3.2',
+          versioncmd: '/usr/local/bin/osqueryi --version | sed "s/osqueryi version //"',
+          to: '/usr/local/bin/osqueryi'
+        }
+#      - { u: 'https://releases.gpgtools.org/GPG_Suite-2018.5.dmg',
+#          v: False,
+#          s: 'c66ecf48ccf709f704f02097cf9d68ba97b0efba24f7a0b7b46adfd1133cb86a'
+#        }
+      - { u: 'https://packages.chef.io/files/stable/inspec/4.18.51/mac_os_x/10.15/inspec-4.18.51-1.dmg',
+          v: True,
+          s: 'efbc8949c34ce12cd0f87bbee57b7535f0f3bc1705c47ac4c490909ec85e3aa5',
+          n: 'inspec',
+          t: 'pkg',
+          m: '/Volumes/InSpec',
+          version: '4.18.51',
+          exec_name: 'inspec-4.18.51-1.pkg',
+          to: '/opt/inspec/bin/inspec',
+          versioncmd: 'inspec --version 2>&1 | head -1'
+        }
+#        https://distfiles.macports.org/MacPorts/MacPorts-2.5.4-10.14-Mojave.pkg
+      - { u: 'https://distfiles.macports.org/MacPorts/MacPorts-2.5.4-10.13-HighSierra.pkg',
+          v: False,
+          s: '07c5c8a62e61c5cb8506cd3b9784dbb06a8fa48c3c6f1e3954f96a82fcb3b77c',
+          n: 'MacPorts',
+          t: 'pkgonly',
+          version: '2.5.4',
+          to: '/opt/local/bin/ports'
+        }
+#      - { u: '',
+#          f: '',
+#          v: True,
+#          s: 'aaaa',
+#          n: '',
+#          t: 'app',
+#          m: '/Volumes/app',
+#          version: '',
+#          versioncmd: '',
+#          to: '/Applications/example.app'
+#        }
+
+  roles:
+    - juju4.macos_apps_install

--- a/test/integration/default/target-user.yml
+++ b/test/integration/default/target-user.yml
@@ -3,6 +3,18 @@
 - hosts: all
   vars:
     verbose: True
+    new_user_username:                        "targetuser"
+    new_user_fullname:                        "Target User"
+    new_user_shell:                           "/bin/zsh"
+    new_user_password_cleartext:              "target-user-password"
+    new_user_generate_ssh_key:                False
+    new_user_reset_password_on_login:         False
+    new_user_is_admin:                        True
+    new_user_update_path_for_all_shell_types: True
+    new_user_profile_picture_path:            ""
+    new_user_random_profile_picture:          False
+    target_user_id: "{{ new_user_username }}"
+    install_archives: "$HOME/Downloads"
     macos_apps_install_list:
       - { u: 'https://download.mozilla.org/?product=firefox-69.0-SSL&os=osx&lang=en-US',
           f: 'firefox-69.0-SSL-en-US.dmg',
@@ -191,4 +203,5 @@
 #        }
 
   roles:
+    - marcomc.macos-new-user
     - juju4.macos_apps_install

--- a/test/integration/default/target-user.yml
+++ b/test/integration/default/target-user.yml
@@ -11,7 +11,6 @@
     new_user_reset_password_on_login:         False
     new_user_is_admin:                        True
     new_user_update_path_for_all_shell_types: True
-    new_user_profile_picture_path:            ""
     new_user_random_profile_picture:          False
     target_user_id:                           "{{ new_user_username }}"
     macos_apps_install_list:

--- a/test/integration/default/target-user.yml
+++ b/test/integration/default/target-user.yml
@@ -14,7 +14,7 @@
     new_user_profile_picture_path:            ""
     new_user_random_profile_picture:          False
     target_user_id: "{{ new_user_username }}"
-    install_archives: "$HOME/Downloads"
+    install_archives: "~/Downloads"
     macos_apps_install_list:
       - { u: 'https://download.mozilla.org/?product=firefox-69.0-SSL&os=osx&lang=en-US',
           f: 'firefox-69.0-SSL-en-US.dmg',

--- a/test/integration/default/target-user.yml
+++ b/test/integration/default/target-user.yml
@@ -3,15 +3,10 @@
 - hosts: all
   vars:
     verbose: True
-    new_user_username:                        "targetuser"
-    new_user_fullname:                        "Target User"
-    new_user_shell:                           "/bin/zsh"
-    new_user_password_cleartext:              "target-user-password"
-    new_user_generate_ssh_key:                False
-    new_user_reset_password_on_login:         False
-    new_user_is_admin:                        True
-    new_user_update_path_for_all_shell_types: True
-    new_user_random_profile_picture:          False
+    new_user_username:                        'targetuser'
+    new_user_fullname:                        'Target User'
+    new_user_shell:                           '/bin/zsh'
+    new_user_password_cleartext:              'target-user-password'
     target_user_id:                           "{{ new_user_username }}"
     macos_apps_install_list:
       - { u: 'https://download.mozilla.org/?product=firefox-69.0-SSL&os=osx&lang=en-US',
@@ -199,7 +194,20 @@
 #          versioncmd: '',
 #          to: '/Applications/example.app'
 #        }
+  pre_tasks:
+    - name: Creating user "{{ new_user_username }}".
+      user:
+        name: "{{ new_user_username }}"
+        comment: "{{ new_user_fullname }}"
+        password: "{{ new_user_password_cleartext }}"
+        shell: '/bin/zsh'
+        home: "/Users/{{ new_user_username }}"
+        create_home: True
+        group: 'staff'
+        groups: 'admin'
+        append: True
+      register: new_user_created
+      become: yes
 
   roles:
-    - marcomc.macos-new-user
     - juju4.macos_apps_install

--- a/test/integration/default/target-user.yml
+++ b/test/integration/default/target-user.yml
@@ -13,8 +13,7 @@
     new_user_update_path_for_all_shell_types: True
     new_user_profile_picture_path:            ""
     new_user_random_profile_picture:          False
-    target_user_id: "{{ new_user_username }}"
-    install_archives: "~/Downloads"
+    target_user_id:                           "{{ new_user_username }}"
     macos_apps_install_list:
       - { u: 'https://download.mozilla.org/?product=firefox-69.0-SSL&os=osx&lang=en-US',
           f: 'firefox-69.0-SSL-en-US.dmg',


### PR DESCRIPTION
- Introduce the option to specify `target_user_id` to specify which user you want the applications to belong to, defaults to `ansible_user_id`
-- `target_user_id` feature required a better tasks grouping for different installer types
- replaces true/false with yes/no: yes/no are native to Ansible and do not require interpretation (fewer CPU cycles)
