### PR TITLE
Fixing copy action for newer versions of macOS

### DIFF
--- a/tasks/archive-install.yml
+++ b/tasks/archive-install.yml
@@ -100,7 +100,7 @@
   become: True
   block:
     # This block is run as super-user because pkg installation frequently contain
-    # system components that require the higher provileges to be installed in system paths
+    # system components that require the higher privileges to be installed in system paths
     - name: INFO
       ansible.builtin.debug:
         msg: "This app will be installed with super-user privileges"

--- a/tasks/archive-install.yml
+++ b/tasks/archive-install.yml
@@ -75,6 +75,7 @@
         dest: "{{ dest }}/"
         mode: preserve
         owner: "{{ target_user_id }}"
+        remote_src: True
       when:
         - archive_extension == '.dmg'
         - installer_type == 'app'


### PR DESCRIPTION
I've found that when installing newer versions of Firefox on newer versions of macOS this was needed in order to copy files from the mounted volumes.